### PR TITLE
Use `gcloud app` instead of `gcloud preview app`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
 - python test_main.py
 # [START deploy]
 # Deploy the app
-- gcloud -q preview app deploy app.yaml --promote
+- gcloud -q app deploy app.yaml --promote
 # Run and end to end test
 - python e2e_test.py
 # [END deploy]


### PR DESCRIPTION
We should use `gcloud app` instead of `gcloud preview app` which will go away soon.
