### PR TITLE
specify python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # Use Dockerized infrastructure
 sudo: false
 language: python
+python: 2.7
 # Cache our Gcloud SDK between commands
 cache:
   directories:


### PR DESCRIPTION
As of April 16th, 2019, Travis uses Python 3.6 by default, which broke this tutorial. 
Specifying Python 2.7 in the Travis.yml file fixes this issue.